### PR TITLE
Fixed DDB table variable name for accounts with multiple tables

### DIFF
--- a/1-app-deploy/README.md
+++ b/1-app-deploy/README.md
@@ -225,7 +225,7 @@ AWS_REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availabil
 FINAL_BUCKET=$(aws s3 ls | grep finalbucket | cut -d' ' -f 3)
 PROCESSING_BUCKET=$(aws s3 ls | grep processingbucket | cut -d' ' -f 3)
 UPLOAD_BUCKET=$(aws s3 ls | grep uploadbucket | cut -d' ' -f 3)  
-DDB_TABLE=$(aws dynamodb list-tables | grep theme-park-backend | awk '{$1=$1};1' | sed 's/"//g')
+DDB_TABLE=$(aws dynamodb list-tables | grep theme-park-backend | awk '{$1=$1};1' | sed 's/",\?//g')
 echo $FINAL_BUCKET
 echo $PROCESSING_BUCKET
 echo $UPLOAD_BUCKET


### PR DESCRIPTION

*Description of changes:*

In the 1-app-deploy section the shell command that sets the DynamoDB table name will set it to "table-name," if the account has more than one DynamoDB table in that region. This updates the sed part of the command to work with multiple tables in the list as well as with a single table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
