### PR TITLE
Fixing typo on file path

### DIFF
--- a/3-photos/1-chromakey/README.md
+++ b/3-photos/1-chromakey/README.md
@@ -123,7 +123,7 @@ You will now test the function using a test image containing a photo of a person
 
 1. Go back to your browser tab with Cloud9 running. If you need to re-launch Cloud9, from the AWS Management Console, select **Services** then select [**Cloud9**](https://console.aws.amazon.com/cloud9) under *Developer Tools*. **Make sure your region is correct.**
 
-2. Navigate to the file `theme-park-backend\3-photos\green-screen-png` and open. You can see the photo of a person with a green screen. This is the local testing image.
+2. Navigate to the file `theme-park-backend\3-photos\green-screen-test.png` and open. You can see the photo of a person with a green screen. This is the local testing image.
 
 3. In the terminal enter the following command to change the directory:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
theme-park-backend\3-photos\green-screen-png replaced with theme-park-backend\3-photos\green-screen-test.png as this is the correct path to the file in the provided repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
