### PR TITLE
Include botocore and correct error class

### DIFF
--- a/3-photos/1-chromakey/app.py
+++ b/3-photos/1-chromakey/app.py
@@ -3,6 +3,7 @@ import json
 import cv2
 import logging
 import boto3
+import botocore
 
 s3 = boto3.client('s3')
 logger = logging.getLogger()
@@ -25,7 +26,7 @@ def upload_file(file_name, bucket, object_name=None):
     s3_client = s3
     try:
         response = s3_client.upload_file(file_name, bucket, object_name)
-    except ClientError as e:
+    except botocore.exceptions.ClientError as e:
         logging.error(e)
         return False
     return True


### PR DESCRIPTION
Including botocore, and updating catch to include full botocore.exceptions.ClientError as per documentation from https://boto3.amazonaws.com/v1/documentation/api/latest/guide/migrations3.html?highlight=clienterror,

Please also see https://github.com/boto/boto3/issues/237 which refers to the fix for the original error in the boto3 documentation

Description of changes:

Running existing code, and passing an incorrect or invalid bucket name, throws an error during the error handling section of the code

```
name 'ClientError' is not defined: NameError
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 111, in lambda_handler
    if upload_file(local_output_temp_file, output_bucket_name, output_file_key):
  File "/var/task/lambda_function.py", line 28, in upload_file
    except ClientError as e:
NameError: name 'ClientError' is not defined
```

Boto3 documentation now states the need to explicitly refer to `botocore.exceptions.ClientError` instead of just `ClientError`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
