### PR TITLE
Fixing typo that specifies 3 ENV vars

### DIFF
--- a/3-photos/3-postprocess/README.md
+++ b/3-photos/3-postprocess/README.md
@@ -46,7 +46,7 @@ After you will test with the sample image, and then perform a test from the fron
 
 ### Adding environment variables
 
-This function uses three environment variables:
+This function uses two environment variables:
 - `IOT_DATA_ENDPOINT`: the IoT endpoint hostname.
 - `DDB_TABLE_NAME`: the DynamoDB table name used by the application.
 


### PR DESCRIPTION
Readme says 
This function uses two environment variables:

there are infact only 2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
