### PR TITLE
Add challenges for advanced learners for module 1 and 2

### DIFF
--- a/1-app-deploy/README.md
+++ b/1-app-deploy/README.md
@@ -368,35 +368,35 @@ In the next module, you will add realtime waiting times for the rides.
     <details>
         <summary>Hint#1</summary>
  
-        Check "Build settings" menu in your Amplify project. Edit the "App build specification section" 
+    Check "Build settings" menu in your Amplify project. Edit the "App build specification section" 
     </details>
 2. Which resources are deployed in the `ride-controller` folders? Could you summarize the responsibility of this stack?
     <details>
         <summary>Hint#1</summary>
  
-        Check file `1-app-deploy/ride-controller/template.yaml`. 
+    Check file `1-app-deploy/ride-controller/template.yaml`. 
     </details>
     <details>
         <summary>Hint#2</summary>
  
-        Look at the two "AWS::Serverless::Function" resources there. Look at its code (from `CodeUri` property) and how it is triggered (from `Events` property)
+    Look at the two "AWS::Serverless::Function" resources there. Look at its code (from `CodeUri` property) and how it is triggered (from `Events` property)
     </details>
-3. We extracted the `$DDB_TABLE` with this code `DDB_TABLE=$(aws cloudformation describe-stack-resource --stack-name theme-park-backend --logical-resource-id DynamoDBTable --query "StackResourceDetail.PhysicalResourceId" --output text)
-`. Could you explain what it does? If you want to extract other resources, how would you change the CLI?
+3. We extracted the variable `$DDB_TABLE` with this code `DDB_TABLE=$(aws cloudformation describe-stack-resource --stack-name theme-park-backend --logical-resource-id DynamoDBTable --query "StackResourceDetail.PhysicalResourceId" --output text)
+`. Could you explain what it does? If you want to extract other resources, how would you change the command?
     <details>
         <summary>Hint#1</summary>
  
-        `$(...COMMAND...)` is called "Command substitution". It executes the command insight and return the output of that command to the DDB_TABLE (instead of printing it out on the screen)
+    `$(...COMMAND...)` is called "Command substitution". It executes the command insight and return the output of that command to the DDB_TABLE (instead of printing it out on the screen)
     </details>
     <details>
         <summary>Hint#2</summary>
  
-        Go to CloudFormation console, select check the `theme-park-backend`, and choose "Resources" tab
+    Go to CloudFormation console, select check the `theme-park-backend`, and choose "Resources" tab
     </details>
     <details>
         <summary>Hint#3</summary>
  
-        Change `--logical-resource-id DynamoDBTable` to `--logical-resource-id UserPool`. What is the returned value?
+    Change `--logical-resource-id DynamoDBTable` to `--logical-resource-id UserPool`. What is the returned value?
     </details>
 ### Next steps
 

--- a/1-app-deploy/README.md
+++ b/1-app-deploy/README.md
@@ -359,6 +359,45 @@ In this module you:
 
 In the next module, you will add realtime waiting times for the rides.
 
+### Challenges for advanced learners
+
+
+> The challenges are optional. If you finish early, we do encourage you to go through it to make the most learning out of this workshop.
+
+1. In frontend build step, you want add CLI command `npm audit` during the frontend build step. How would you do that?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        Check "Build settings" menu in your Amplify project. Edit the "App build specification section" 
+    </details>
+2. Which resources are deployed in the `ride-controller` folders? Could you summarize the responsibility of this stack?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        Check file `1-app-deploy/ride-controller/template.yaml`. 
+    </details>
+    <details>
+        <summary>Hint#2</summary>
+ 
+        Look at the two "AWS::Serverless::Function" resources there. Look at its code (from `CodeUri` property) and how it is triggered (from `Events` property)
+    </details>
+3. We extracted the `$DDB_TABLE` with this code `DDB_TABLE=$(aws cloudformation describe-stack-resource --stack-name theme-park-backend --logical-resource-id DynamoDBTable --query "StackResourceDetail.PhysicalResourceId" --output text)
+`. Could you explain what it does? If you want to extract other resources, how would you change the CLI?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        `$(...COMMAND...)` is called "Command substitution". It executes the command insight and return the output of that command to the DDB_TABLE (instead of printing it out on the screen)
+    </details>
+    <details>
+        <summary>Hint#2</summary>
+ 
+        Go to CloudFormation console, select check the `theme-park-backend`, and choose "Resources" tab
+    </details>
+    <details>
+        <summary>Hint#3</summary>
+ 
+        Change `--logical-resource-id DynamoDBTable` to `--logical-resource-id UserPool`. What is the returned value?
+    </details>
 ### Next steps
 
 [Click here](../2-realtime/README.md) to continue to Module 2.

--- a/2-realtime/README.md
+++ b/2-realtime/README.md
@@ -183,6 +183,50 @@ In this module you:
 
 Once you have seen the new functionality in the published application URL, proceed to the next module, where you will add ride photo processing.
 
+### Challenges for advanced learners
+
+
+> The challenges are optional. If you finish early, we do encourage you to go through it to make the most learning out of this workshop.
+
+1. Why is ride updated every minute? Which line in the code causes that?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        The answer lies in the stack you deployed in the previous module. `theme-park-ride-times`  (in the folder `1-app-deploy/ride-controller`)
+    </details>
+    <details>
+        <summary>Hint#2</summary>
+ 
+        Look at the `template.yaml` file. Find the `UpdateRides` function. Check its "Events" property
+    </details>
+2. How is the message passed from SNS to IoT topic?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        In the Lambda function you created in this module, you add "Trigger" from SNS. This causes Lambda to be called with the passed message from SNS.
+    </details>
+    <details>
+        <summary>Hint#2</summary>
+ 
+        Look at the code you put in the Lambda function. Find `iotdata.publish` in that code.
+    </details>
+3. How does frontend retrieve messages from the IoT topic?
+    <details>
+        <summary>Hint#1</summary>
+ 
+        Frontend open a WebSocket with IoT endpoint to receive messages from IoT topic via MQTT (a pub-sub protocol). There must be a code related to this in `theme-park-frontend` folder 
+    </details>
+    <details>
+        <summary>Hint#2</summary>
+ 
+        Use CMD + Shift + F (or CTRL + Shift + F in Windows) to search all files in the `theme-park-frontend` folder. Use keywords like 'iot' or 'mqtt'
+    </details>
+    <details>
+        <summary>Hint#3</summary>
+ 
+        Search for `mqttClient.on`. See how mqttClient is initialized, how it gets the credential to authenticate with endpoint, and how it handle `mqttClient.on('message').
+    </details>
+
 ## Next steps ## 
 
 [Click here](../3-photos/README.md) to continue to Module 3.

--- a/2-realtime/README.md
+++ b/2-realtime/README.md
@@ -192,39 +192,39 @@ Once you have seen the new functionality in the published application URL, proce
     <details>
         <summary>Hint#1</summary>
  
-        The answer lies in the stack you deployed in the previous module. `theme-park-ride-times`  (in the folder `1-app-deploy/ride-controller`)
+    The answer lies in the stack you deployed in the previous module. `theme-park-ride-times`  (in the folder `1-app-deploy/ride-controller`)
     </details>
     <details>
         <summary>Hint#2</summary>
  
-        Look at the `template.yaml` file. Find the `UpdateRides` function. Check its "Events" property
+    Look at the `template.yaml` file. Find the `UpdateRides` function. Check its "Events" property
     </details>
 2. How is the message passed from SNS to IoT topic?
     <details>
         <summary>Hint#1</summary>
  
-        In the Lambda function you created in this module, you add "Trigger" from SNS. This causes Lambda to be called with the passed message from SNS.
+    In the Lambda function you created in this module, you add "Trigger" from SNS. This causes Lambda to be called with the passed message from SNS.
     </details>
     <details>
         <summary>Hint#2</summary>
  
-        Look at the code you put in the Lambda function. Find `iotdata.publish` in that code.
+    Look at the code you put in the Lambda function. Find `iotdata.publish` in that code.
     </details>
 3. How does frontend retrieve messages from the IoT topic?
     <details>
         <summary>Hint#1</summary>
  
-        Frontend open a WebSocket with IoT endpoint to receive messages from IoT topic via MQTT (a pub-sub protocol). There must be a code related to this in `theme-park-frontend` folder 
+    Frontend open a WebSocket with IoT endpoint to receive messages from IoT topic via MQTT (a pub-sub protocol). There must be a code related to this in `theme-park-frontend` folder 
     </details>
     <details>
         <summary>Hint#2</summary>
  
-        Use CMD + Shift + F (or CTRL + Shift + F in Windows) to search all files in the `theme-park-frontend` folder. Use keywords like 'iot' or 'mqtt'
+    Use CMD + Shift + F (or CTRL + Shift + F in Windows) to search all files in the `theme-park-frontend` folder. Use keywords like 'iot' or 'mqtt'
     </details>
     <details>
         <summary>Hint#3</summary>
  
-        Search for `mqttClient.on`. See how mqttClient is initialized, how it gets the credential to authenticate with endpoint, and how it handle `mqttClient.on('message').
+    Search for `mqttClient.on`. See how mqttClient is initialized, how it gets the credential to authenticate with endpoint, and how it handle `mqttClient.on('message').
     </details>
 
 ## Next steps ## 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

**Context**: Some attendees who goes very fast just copy & paste without really see what they deployed in SAM (and do not learn much).  On the other hands, slower audience felt frustrated and it's harder to facilitator to manage.

**Change**: Add  optional "Challenges for advanced learners" at the end of each module 1 and 2.  The goal is to pause fast attendees to think and reflect to make sure that they understand what they are doing.  I also added multiple hints in case they get stuck (to minimize facilitator overhead to answer these questions).

**For reviewers**: The rendered versions are here:
1. https://github.com/ijemmy/aws-serverless-workshop-innovator-island/tree/ijemmy/add-challenges-for-module1-and-2/1-app-deploy#challenges-for-advanced-learners
2. https://github.com/ijemmy/aws-serverless-workshop-innovator-island/tree/ijemmy/add-challenges-for-module1-and-2/2-realtime#challenges-for-advanced-learners 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
