### PR TITLE
Amplify role

### DIFF
--- a/0-cleanup/cleanup-script.sh
+++ b/0-cleanup/cleanup-script.sh
@@ -7,11 +7,13 @@ PROCESSING_BUCKET=$(aws cloudformation describe-stack-resource --stack-name them
 UPLOAD_BUCKET=$(aws cloudformation describe-stack-resource --stack-name theme-park-backend --logical-resource-id UploadBucket --query "StackResourceDetail.PhysicalResourceId" --output text)
 accountId=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 s3_deploy_bucket="theme-park-sam-deploys-${accountId}"
+s3_deploy_amplify_role_bucket="theme-park-amplify-role-${accountId}"
 
 aws s3 rb "s3://${FINAL_BUCKET}" --force
 aws s3 rb "s3://${PROCESSING_BUCKET}" --force
 aws s3 rb "s3://${UPLOAD_BUCKET}" --force
 aws s3 rb "s3://${s3_deploy_bucket}" --force
+aws s3 rb "s3://${s3_deploy_amplify_role_bucket}" --force
 aws s3 rb "s3://theme-park-data-${accountId}-${AWS_REGION}" --force
 
 prefix="theme-park"
@@ -57,6 +59,3 @@ rm -rf ~/environment/theme-park-backend/4-translate/local-app/node_modules
 #    TOPIC_ARN=$(aws sns list-topics --region $AWS_REGION | jq -r ".Topics[] | select(.TopicArn | contains(\"$TOPIC\")) | .TopicArn")
 #    aws sns delete-topic --region $AWS_REGION --topic-arn $TOPIC_ARN
 #done
-
-
-

--- a/1-app-deploy/amplify-role/template.yaml
+++ b/1-app-deploy/amplify-role/template.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Innovator Island - AWS Amplify Role
+
+Resources:
+  AmplifyRoleForInnovatorIsland:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'amplify.amazonaws.com'
+            Action: 'sts:AssumeRole'
+      Path: '/'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AdministratorAccess-Amplify

--- a/1-app-deploy/module1a-script.sh
+++ b/1-app-deploy/module1a-script.sh
@@ -26,6 +26,18 @@ TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-meta
 AWS_REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
 git push --set-upstream https://git-codecommit.$AWS_REGION.amazonaws.com/v1/repos/theme-park-frontend main
 
+##Deploy Amazon AmplifyRole
+accountId=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
+s3_deploy_bucket="theme-park-amplify-role-${accountId}"
+echo $s3_deploy_bucket
+aws s3 mb s3://$s3_deploy_bucket
+
+##Deploy ride controller
+cd ~/environment/theme-park-backend/1-app-deploy/amplify-role/
+sam build
+sam package --output-template-file packaged.yaml --s3-bucket $s3_deploy_bucket
+sam deploy --template-file packaged.yaml --stack-name theme-park-amplify-role --capabilities CAPABILITY_IAM
+
 
 
 #############Deploy the site with the AWS Amplify Console

--- a/1-app-deploy/module1a-script.sh
+++ b/1-app-deploy/module1a-script.sh
@@ -26,13 +26,12 @@ TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-meta
 AWS_REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
 git push --set-upstream https://git-codecommit.$AWS_REGION.amazonaws.com/v1/repos/theme-park-frontend main
 
-##Deploy Amazon AmplifyRole
+##Deploy AWS Amplify Role
 accountId=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 s3_deploy_bucket="theme-park-amplify-role-${accountId}"
 echo $s3_deploy_bucket
 aws s3 mb s3://$s3_deploy_bucket
 
-##Deploy ride controller
 cd ~/environment/theme-park-backend/1-app-deploy/amplify-role/
 sam build
 sam package --output-template-file packaged.yaml --s3-bucket $s3_deploy_bucket


### PR DESCRIPTION
*Issue #, if available:*  The recent changes to AWS Amplify's UI require a new IAM role, but there is currently no built-in way to set this role during the app deployment creation process. 

*Description of changes:* To overcome this UI limitation, I have added changes that deploy a new IAM role to be used in the app's edit settings.
More information can be found in the [AWS Amplify Hosting](https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html#getting-started-prerequisites) documentation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
